### PR TITLE
Configuration file is not required.

### DIFF
--- a/crappyspider/spiders/crappyspider.py
+++ b/crappyspider/spiders/crappyspider.py
@@ -26,7 +26,7 @@ class CrappySpider(Spider):
         if not config and (not start_urls or not allowed_domains):
             raise ValueError('Requires the start_urls and allowed_domains '
                              ' parameters which can be'
-                             ' configured in the config file or using'
+                             ' configured in the config file or using the'
                              ' command line. For example:'
                              ' scrapy crawl crappyspider -a '
                              ' start_urls=http://test.com'


### PR DESCRIPTION
Check if the start_urls or allowed_domains is define on the command line or in the configuration file, and configuration file is not required now.
