### PR TITLE
Add a alternative syntax for credentials in the config file

### DIFF
--- a/crappyspider/spiders/crappyspider.py
+++ b/crappyspider/spiders/crappyspider.py
@@ -58,9 +58,18 @@ class CrappySpider(Spider):
         credential = self.config.get('credential', None)
 
         if credential:
+            if isinstance(credential, dict):
+                return [FormRequest.from_response(
+                    response, formdata=self.config['credential'],
+                    callback=self.after_login, errback=self.login_error)]
+
+            data = {}
+            for field in credential:
+                data[field] = os.environ['CRAPPYSPIDER_' + field.upper()]
+
             return [FormRequest.from_response(
-                response, formdata=self.config['credential'],
-                callback=self.after_login, errback=self.login_error)]
+                response, formdata=data, callback=self.after_login,
+                errback=self.login_error)]
 
         return Request(response.url, callback=self.parse_page)
 

--- a/crappyspider/spiders/crappyspider.py
+++ b/crappyspider/spiders/crappyspider.py
@@ -63,6 +63,7 @@ class CrappySpider(Spider):
                     response, formdata=self.config['credential'],
                     callback=self.after_login, errback=self.login_error)]
 
+            # Get the crendetial from environnement
             data = {}
             for field in credential:
                 data[field] = os.environ['CRAPPYSPIDER_' + field.upper()]

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -45,6 +45,37 @@ Credential
 The credential hash is optional since it is used for sites requiring login.
 The underlying hashes are used as names for the login form inputs, so you might have to change them.
 
+Example:
+
+.. code-block:: json
+
+    {
+        "credential": {
+            "email": "myemail",
+            "password": "mypassword"
+        },
+    }
+
+There's another credential scheme, take a list, with the name of the field.
+
+Example:
+
+.. code-block:: json
+
+    {
+        "credential": ["email", "password"]
+    }
+
+Then add in your environnement two variables.
+
+Example:
+
+.. code-block:: bash
+
+    export CRAPPYSPIDER_EMAIL=test@test.com
+    export CRAPPYSPIDER_PASSWORD=my_password
+
+
 Login error selector
 --------------------
 The selector where the crawler should look for errors after a login attempt.


### PR DESCRIPTION
This would allow tu user to only specify the login form fields names. The values for these fields would then have to be passer as CLI arguments.